### PR TITLE
chore: remove build check on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   workflow_dispatch: # nothing here
 jobs:
   build-linux:


### PR DESCRIPTION
Steamworks fails to download for PRs so just disable it on those